### PR TITLE
Add taproot support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## [0.5.0] [2025-11-27]
+
+### Added
+
+- BIP86 (taproot) support in `GenericJson` and `Json` formats
+- Support for Passport hardware wallet exports (and other wallets that use zpub/ypub directly in JSON)
+- Update deps
+
+### Breaking
+
+- `Format::Json` now contains `Box<Json>` instead of `Json`
+- Added `bip86` field to `Json` and `GenericJson` structs
+
 ## [0.4.1] [2025-11-27]
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arrayvec"
@@ -15,10 +15,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
+name = "askama"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base58ck"
@@ -47,9 +89,9 @@ checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "0fda569d741b895131a88ee5589a467e73e9c4718e958ac9308e4f7dc44b6945"
 dependencies = [
  "base58ck",
  "bech32",
@@ -57,7 +99,7 @@ dependencies = [
  "bitcoin-io",
  "bitcoin-units",
  "bitcoin_hashes",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1",
  "serde",
@@ -95,23 +137,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
  "serde",
 ]
 
 [[package]]
-name = "bytes"
-version = "1.10.1"
+name = "bitflags"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "bytes"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "276a59bf2b2c967788139340c9f0c5b12d7fd6630315c15c217e559de85d2609"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -125,26 +173,33 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "derive_more"
@@ -174,6 +229,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,10 +266,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.2"
+name = "getrandom"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "goblin"
@@ -200,6 +295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,12 +308,18 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex-conservative"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "hex-conservative"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee770c000993d17c185713463d5ebfbd1af9afae4c17cc295640104383bfbf0"
 
 [[package]]
 name = "hex_lit"
@@ -221,38 +328,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "log"
-version = "0.4.26"
+name = "libc"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "minimal-lexical"
@@ -262,12 +377,13 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniscript"
-version = "12.3.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd3c9608217b0d6fa9c9c8ddd875b85ab72bd4311cfc8db35e1b5a08fc11f4d"
+checksum = "867b1f11e0545ad5ebbddd8a9f18756d9657a6758bf10d96cf15ddd0b726b650"
 dependencies = [
  "bech32",
  "bitcoin",
+ "hex-conservative 1.0.0",
 ]
 
 [[package]]
@@ -282,15 +398,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "percent-encoding"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "plain"
@@ -310,16 +426,16 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "pubport"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bitcoin",
  "derive_more",
@@ -329,63 +445,43 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror",
  "uniffi",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.39"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rinja"
-version = "0.3.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc4940d00595430b3d7d5a01f6222b5e5b51395d1120bdb28d854bb8abb17a5"
-dependencies = [
- "itoa",
- "rinja_derive",
-]
-
-[[package]]
-name = "rinja_derive"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d9ed0146aef6e2825f1b1515f074510549efba38d71f4554eec32eb36ba18b"
-dependencies = [
- "basic-toml",
- "memchr",
- "mime",
- "mime_guess",
- "proc-macro2",
- "quote",
- "rinja_parser",
- "rustc-hash",
- "serde",
- "syn",
-]
-
-[[package]]
-name = "rinja_parser"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f9a866e2e00a7a1fb27e46e9e324a6f7c0e7edc4543cae1d38f4e4a100c610"
-dependencies = [
- "memchr",
- "nom",
- "serde",
-]
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "ryu"
@@ -404,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -435,27 +531,38 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -464,14 +571,24 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -500,13 +617,26 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -520,38 +650,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
-dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -560,24 +670,48 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
 dependencies = [
- "serde",
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
-name = "unicase"
-version = "2.8.1"
+name = "toml_datetime"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-xid"
@@ -587,68 +721,74 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62a57e90f9baed5ad02a71a0870180fa1cc35499093b2d21be2edfb68ec0f7"
+checksum = "c866f627c3f04c3df068b68bb2d725492caaa539dd313e2a9d26bb85b1a32f4e"
 dependencies = [
  "anyhow",
  "cargo_metadata",
  "uniffi_bindgen",
  "uniffi_core",
  "uniffi_macros",
+ "uniffi_pipeline",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2242f35214f1e0e3b47c495d340c69f649f9a9ece3a943a29e275686cc884533"
+checksum = "7c8ca600167641ebe7c8ba9254af40492dda3397c528cc3b2f511bd23e8541a5"
 dependencies = [
  "anyhow",
+ "askama",
  "camino",
  "cargo_metadata",
  "fs-err",
  "glob",
  "goblin",
  "heck",
+ "indexmap",
  "once_cell",
- "paste",
- "rinja",
  "serde",
+ "tempfile",
  "textwrap",
  "toml",
+ "uniffi_internal_macros",
  "uniffi_meta",
+ "uniffi_pipeline",
  "uniffi_udl",
 ]
 
 [[package]]
 name = "uniffi_core"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad9fbdeb7ae4daf8d0f7704a3b638c37018eb16bb701e30fa17a2dd3e2d39c1"
+checksum = "7e7a5a038ebffe8f4cf91416b154ef3c2468b18e828b7009e01b1b99938089f9"
 dependencies = [
  "anyhow",
  "bytes",
  "once_cell",
- "paste",
  "static_assertions",
 ]
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9dba1d78b9ce429439891089c223478043d52a1c3176a0fcea2b5573a7fcf"
+checksum = "e3c2a6f93e7b73726e2015696ece25ca0ac5a5f1cf8d6a7ab5214dd0a01d2edf"
 dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "uniffi_macros"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78dd5f8eefba5898b901086f5e7916da67b9a5286a01cc44e910cd75fa37c630"
+checksum = "64c6309fc36c7992afc03bc0c5b059c656bccbef3f2a4bc362980017f8936141"
 dependencies = [
  "camino",
  "fs-err",
@@ -663,25 +803,48 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5965b1d4ffacef1eaa72fef9c00d2491641e87ad910f6c5859b9c503ddb16a"
+checksum = "0a138823392dba19b0aa494872689f97d0ee157de5852e2bec157ce6de9cdc22"
 dependencies = [
  "anyhow",
  "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c27c4b515d25f8e53cc918e238c39a79c3144a40eaf2e51c4a7958973422c29"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "tempfile",
  "uniffi_internal_macros",
 ]
 
 [[package]]
 name = "uniffi_udl"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279b82bac9a382c796a0d210bb8354a0b813499b28aa1de046c85d78ca389805"
+checksum = "d0adacdd848aeed7af4f5af7d2f621d5e82531325d405e29463482becfdeafca"
 dependencies = [
  "anyhow",
  "textwrap",
  "uniffi_meta",
  "weedle2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -692,6 +855,36 @@ checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubport"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for parsing hardware wallet export formats"
@@ -18,7 +18,7 @@ uniffi = ["dep:uniffi"]
 [dependencies]
 # Bitcoin
 bitcoin = { version = "0.32", features = ["serde"] }
-miniscript = { version = "12.0", features = [] }
+miniscript = { version = "13.0", features = [] }
 
 # errors
 thiserror = "2.0"
@@ -38,7 +38,7 @@ memchr = "2.7"
 
 ## optional
 # ffi
-uniffi = { version = "0.29", optional = true }
+uniffi = { version = "0.30", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.4"

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -120,7 +120,16 @@ impl Descriptors {
         }
 
         let script_type = single_sig.name.ok_or(Error::MissingScriptType)?;
-        let xpub = single_sig.xpub.ok_or(Error::MissingXpub)?;
+        let xpub_str = single_sig.xpub.ok_or(Error::MissingXpub)?;
+
+        // convert SLIP-132 encoded keys (zpub, ypub) to standard xpub format
+        let xpub = if xpub_str.starts_with("zpub") {
+            xpub::zpub_to_xpub(&xpub_str)?
+        } else if xpub_str.starts_with("ypub") {
+            xpub::ypub_to_xpub(&xpub_str)?
+        } else {
+            xpub_str
+        };
 
         let fingerprint = fingerprint
             .ok_or(Error::MissingFingerprint)?

--- a/src/descriptor/script_type.rs
+++ b/src/descriptor/script_type.rs
@@ -1,7 +1,7 @@
 use bitcoin::bip32::DerivationPath;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum ScriptType {
     /// BIP44 [44h/0h/0h]
@@ -12,6 +12,9 @@ pub enum ScriptType {
 
     /// BIP84 [84h/0h/0h]
     P2wpkh,
+
+    /// BIP86 [86h/0h/0h]
+    P2tr,
 }
 
 const HARDENED_FLAG: u32 = 1 << 31;
@@ -19,6 +22,7 @@ const HARDENED_FLAG: u32 = 1 << 31;
 const HARDENED_44: u32 = 44 ^ HARDENED_FLAG;
 const HARDENED_49: u32 = 49 ^ HARDENED_FLAG;
 const HARDENED_84: u32 = 84 ^ HARDENED_FLAG;
+const HARDENED_86: u32 = 86 ^ HARDENED_FLAG;
 
 #[derive(Debug, Clone, Serialize, Deserialize, thiserror::Error, PartialEq, Eq)]
 pub enum Error {
@@ -41,9 +45,11 @@ impl ScriptType {
             [HARDENED_44, _, _] => hardened_or_error(&path[1..], ScriptType::P2pkh),
             [HARDENED_49, _, _] => hardened_or_error(&path[1..], ScriptType::P2shP2wpkh),
             [HARDENED_84, _, _] => hardened_or_error(&path[1..], ScriptType::P2wpkh),
+            [HARDENED_86, _, _] => hardened_or_error(&path[1..], ScriptType::P2tr),
             [44, _, _] => Err(Error::NotHardened),
             [49, _, _] => Err(Error::NotHardened),
             [84, _, _] => Err(Error::NotHardened),
+            [86, _, _] => Err(Error::NotHardened),
             _ => Err(Error::InvalidPath(path.to_vec())),
         }
     }
@@ -53,6 +59,7 @@ impl ScriptType {
             ScriptType::P2pkh => "44'/0'/0'",
             ScriptType::P2shP2wpkh => "49'/0'/0'",
             ScriptType::P2wpkh => "84'/0'/0'",
+            ScriptType::P2tr => "86'/0'/0'",
         }
     }
 
@@ -61,6 +68,7 @@ impl ScriptType {
             ScriptType::P2pkh => format!("pkh({})", script),
             ScriptType::P2shP2wpkh => format!("sh(wpkh({}))", script),
             ScriptType::P2wpkh => format!("wpkh({})", script),
+            ScriptType::P2tr => format!("tr({})", script),
         }
     }
 }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    descriptor::{self, Descriptors},
+    descriptor::{self, Descriptors, ScriptType},
     json::{self, GenericJson},
     key_expression::KeyExpression,
     xpub,
@@ -11,7 +11,7 @@ use crate::{
 #[cfg_attr(feature = "uniffi", derive(uniffi::Object))]
 pub enum Format {
     Descriptor(Descriptors),
-    Json(Json),
+    Json(Box<Json>),
     Wasabi(Descriptors),
     Electrum(Descriptors),
     KeyExpression(Descriptors),
@@ -41,32 +41,54 @@ pub struct Json {
     pub bip44: Option<Descriptors>,
     pub bip49: Option<Descriptors>,
     pub bip84: Option<Descriptors>,
+    pub bip86: Option<Descriptors>,
 }
 
 impl TryFrom<GenericJson> for Json {
     type Error = Error;
 
     fn try_from(json: GenericJson) -> Result<Self, Self::Error> {
-        if json.bip44.is_none() && json.bip49.is_none() && json.bip84.is_none() {
+        if json.bip44.is_none()
+            && json.bip49.is_none()
+            && json.bip84.is_none()
+            && json.bip86.is_none()
+        {
             return Err(Error::JsonNoDecriptor);
         }
 
         let bip44 = json
             .bip44
-            .map(|single_sig| Descriptors::try_from_single_sig(single_sig, json.xfp.as_deref()))
+            .map(|mut single_sig| {
+                single_sig.name.get_or_insert(ScriptType::P2pkh);
+                Descriptors::try_from_single_sig(single_sig, json.xfp.as_deref())
+            })
             .transpose()?;
 
         let bip49 = json
             .bip49
-            .map(|single_sig| Descriptors::try_from_single_sig(single_sig, json.xfp.as_deref()))
+            .map(|mut single_sig| {
+                single_sig.name.get_or_insert(ScriptType::P2shP2wpkh);
+                Descriptors::try_from_single_sig(single_sig, json.xfp.as_deref())
+            })
             .transpose()?;
 
         let bip84 = json
             .bip84
-            .map(|single_sig| Descriptors::try_from_single_sig(single_sig, json.xfp.as_deref()))
+            .map(|mut single_sig| {
+                single_sig.name.get_or_insert(ScriptType::P2wpkh);
+                Descriptors::try_from_single_sig(single_sig, json.xfp.as_deref())
+            })
             .transpose()?;
 
-        if bip44.is_none() && bip49.is_none() && bip84.is_none() {
+        let bip86 = json
+            .bip86
+            .map(|mut single_sig| {
+                single_sig.name.get_or_insert(ScriptType::P2tr);
+                Descriptors::try_from_single_sig(single_sig, json.xfp.as_deref())
+            })
+            .transpose()?;
+
+        if bip44.is_none() && bip49.is_none() && bip84.is_none() && bip86.is_none() {
             return Err(Error::JsonNoDecriptor);
         }
 
@@ -74,6 +96,7 @@ impl TryFrom<GenericJson> for Json {
             bip44,
             bip49,
             bip84,
+            bip86,
         })
     }
 }
@@ -82,7 +105,7 @@ impl Format {
     pub fn try_new_from_str(string: &str) -> Result<Self, Error> {
         if let Ok(json) = serde_json::from_str::<json::GenericJson>(string) {
             if let Ok(json) = Json::try_from(json) {
-                return Ok(Format::Json(json));
+                return Ok(Format::Json(Box::new(json)));
             }
         }
 
@@ -108,11 +131,11 @@ impl Format {
             }
 
             let json = Json::try_from_child_xpub(key_expression.xpub)?;
-            return Ok(Format::Json(json));
+            return Ok(Format::Json(Box::new(json)));
         }
 
         let json = Json::try_from_child_xpub_str(string)?;
-        Ok(Format::Json(json))
+        Ok(Format::Json(Box::new(json)))
     }
 }
 
@@ -151,5 +174,61 @@ mod tests {
         let string = std::fs::read_to_string("test/data/krux.txt").unwrap();
         let krux = KeyExpression::try_from_str(&string);
         assert!(krux.is_ok());
+    }
+
+    /// Test bip86 parsing with zpub (SLIP-132 format)
+    #[test]
+    fn test_json_format_includes_bip86_with_zpub() {
+        let json_str = r#"{
+  "xfp": "73c5da0a",
+  "bip84": {
+    "deriv": "m/84'/0'/0'",
+    "xpub": "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+    "first": "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+  },
+  "bip86": {
+    "deriv": "m/86'/0'/0'",
+    "xpub": "xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ",
+    "first": "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"
+  }
+}"#;
+
+        let format = Format::try_new_from_str(json_str).expect("Failed to parse");
+
+        match format {
+            Format::Json(json) => {
+                assert!(json.bip84.is_some(), "bip84 should be present");
+                assert!(json.bip86.is_some(), "bip86 should be present");
+            }
+            _ => panic!("Expected Format::Json"),
+        }
+    }
+
+    /// Test bip86 parsing with standard xpub format
+    #[test]
+    fn test_json_format_includes_bip86_with_xpub() {
+        let json_str = r#"{
+  "xfp": "817e7be0",
+  "bip84": {
+    "deriv": "m/84'/0'/0'",
+    "xpub": "xpub6CiKnWv7PPyyeb4kCwK4fidKqVjPfD9TP6MiXnzBVGZYNanNdY3mMvywcrdDc6wK82jyBSd95vsk26QujnJWPrSaPfYeyW7NyX37HHGtfQM",
+    "first": "bc1q0g0vn4yqyk0zjwxw0zv5pltyyczty004zc9g7r"
+  },
+  "bip86": {
+    "deriv": "m/86'/0'/0'",
+    "xpub": "xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ",
+    "first": "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"
+  }
+}"#;
+
+        let format = Format::try_new_from_str(json_str).expect("Failed to parse");
+
+        match format {
+            Format::Json(json) => {
+                assert!(json.bip84.is_some(), "bip84 should be present");
+                assert!(json.bip86.is_some(), "bip86 should be present");
+            }
+            _ => panic!("Expected Format::Json"),
+        }
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -124,4 +124,85 @@ mod tests {
         let single_sig = serde_json::from_str::<SingleSig>(json);
         assert!(single_sig.is_ok());
     }
+
+    /// Test Passport wallet export JSON format (Foundation Devices)
+    ///
+    /// This JSON format is used by Passport hardware wallet when exporting
+    /// wallet data via ur:bytes QR codes.
+    ///
+    /// Uses the "abandon" seed test vector:
+    /// - BIP39: "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
+    /// - Master fingerprint: 73c5da0a
+    /// - BIP84 first address: bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu
+    #[test]
+    fn test_deserialize_passport_format() {
+        let passport_json = r#"{
+  "xfp": "73c5da0a",
+  "bip84": {
+    "deriv": "m/84'/0'/0'",
+    "xpub": "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+    "first": "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+  }
+}"#;
+
+        let generic = serde_json::from_str::<GenericJson>(passport_json);
+        assert!(generic.is_ok(), "Failed to parse Passport JSON: {:?}", generic.err());
+
+        let generic = generic.unwrap();
+
+        // verify master fingerprint
+        assert_eq!(generic.xfp, Some("73c5da0a".to_string()));
+
+        // verify bip84 data
+        let bip84 = generic.bip84.expect("Should have bip84 data");
+        assert_eq!(bip84.deriv, Some("m/84'/0'/0'".to_string()));
+        assert!(bip84.xpub.as_ref().unwrap().starts_with("zpub"));
+        assert_eq!(
+            bip84.first,
+            Some("bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu".to_string())
+        );
+    }
+
+    /// Test Passport export with multiple BIP paths
+    #[test]
+    fn test_deserialize_passport_full_export() {
+        let passport_json = r#"{
+  "chain": "BTC",
+  "xfp": "73c5da0a",
+  "account": 0,
+  "bip44": {
+    "deriv": "m/44'/0'/0'",
+    "xpub": "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj",
+    "first": "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
+  },
+  "bip49": {
+    "deriv": "m/49'/0'/0'",
+    "xpub": "ypub6Ww3ibxVfGzLtJR4F9SRBicspAfvmvw54yern9Q6qZWFC9T6FYA34K57La5Sgs8pXuyvpDfEHX5KNZRiZRukUWaVPyL4NxA69sEAqdoV8ve",
+    "first": "37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf"
+  },
+  "bip84": {
+    "deriv": "m/84'/0'/0'",
+    "xpub": "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+    "first": "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+  }
+}"#;
+
+        let generic = serde_json::from_str::<GenericJson>(passport_json);
+        assert!(generic.is_ok(), "Failed to parse full Passport export: {:?}", generic.err());
+
+        let generic = generic.unwrap();
+
+        // verify chain
+        assert_eq!(generic.chain, Some("BTC".to_string()));
+
+        // verify all three BIP paths are present
+        assert!(generic.bip44.is_some(), "Should have bip44");
+        assert!(generic.bip49.is_some(), "Should have bip49");
+        assert!(generic.bip84.is_some(), "Should have bip84");
+
+        // verify xpub prefixes match expected formats
+        assert!(generic.bip44.as_ref().unwrap().xpub.as_ref().unwrap().starts_with("xpub"));
+        assert!(generic.bip49.as_ref().unwrap().xpub.as_ref().unwrap().starts_with("ypub"));
+        assert!(generic.bip84.as_ref().unwrap().xpub.as_ref().unwrap().starts_with("zpub"));
+    }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -170,7 +170,54 @@ mod tests {
         );
     }
 
-    /// Test Passport export with multiple BIP paths
+    /// Test GenericJson with only bip84 (single path)
+    #[test]
+    fn test_deserialize_generic_single_path() {
+        let json = r#"{
+  "xfp": "73c5da0a",
+  "bip84": {
+    "deriv": "m/84'/0'/0'",
+    "xpub": "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+    "first": "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+  }
+}"#;
+
+        let generic = serde_json::from_str::<GenericJson>(json).unwrap();
+
+        assert_eq!(generic.xfp, Some("73c5da0a".to_string()));
+        assert!(generic.bip84.is_some());
+        assert!(generic.bip44.is_none());
+        assert!(generic.bip49.is_none());
+        assert!(generic.bip86.is_none());
+    }
+
+    /// Test GenericJson with bip84 and bip86 (taproot)
+    #[test]
+    fn test_deserialize_generic_with_taproot() {
+        let json = r#"{
+  "xfp": "73c5da0a",
+  "bip84": {
+    "deriv": "m/84'/0'/0'",
+    "xpub": "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+    "first": "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+  },
+  "bip86": {
+    "deriv": "m/86'/0'/0'",
+    "xpub": "xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ",
+    "first": "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"
+  }
+}"#;
+
+        let generic = serde_json::from_str::<GenericJson>(json).unwrap();
+
+        assert_eq!(generic.xfp, Some("73c5da0a".to_string()));
+        assert!(generic.bip84.is_some());
+        assert!(generic.bip86.is_some());
+        assert!(generic.bip44.is_none());
+        assert!(generic.bip49.is_none());
+    }
+
+    /// Test Passport export with multiple BIP paths including taproot
     #[test]
     fn test_deserialize_passport_full_export() {
         let passport_json = r#"{
@@ -191,25 +238,74 @@ mod tests {
     "deriv": "m/84'/0'/0'",
     "xpub": "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
     "first": "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+  },
+  "bip86": {
+    "deriv": "m/86'/0'/0'",
+    "xpub": "xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ",
+    "first": "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr"
   }
 }"#;
 
         let generic = serde_json::from_str::<GenericJson>(passport_json);
-        assert!(generic.is_ok(), "Failed to parse full Passport export: {:?}", generic.err());
+        assert!(
+            generic.is_ok(),
+            "Failed to parse full Passport export: {:?}",
+            generic.err()
+        );
 
         let generic = generic.unwrap();
 
         // verify chain
         assert_eq!(generic.chain, Some("BTC".to_string()));
 
-        // verify all three BIP paths are present
+        // verify all four BIP paths are present
         assert!(generic.bip44.is_some(), "Should have bip44");
         assert!(generic.bip49.is_some(), "Should have bip49");
         assert!(generic.bip84.is_some(), "Should have bip84");
+        assert!(generic.bip86.is_some(), "Should have bip86");
 
         // verify xpub prefixes match expected formats
-        assert!(generic.bip44.as_ref().unwrap().xpub.as_ref().unwrap().starts_with("xpub"));
-        assert!(generic.bip49.as_ref().unwrap().xpub.as_ref().unwrap().starts_with("ypub"));
-        assert!(generic.bip84.as_ref().unwrap().xpub.as_ref().unwrap().starts_with("zpub"));
+        assert!(generic
+            .bip44
+            .as_ref()
+            .unwrap()
+            .xpub
+            .as_ref()
+            .unwrap()
+            .starts_with("xpub"));
+        assert!(generic
+            .bip49
+            .as_ref()
+            .unwrap()
+            .xpub
+            .as_ref()
+            .unwrap()
+            .starts_with("ypub"));
+        assert!(generic
+            .bip84
+            .as_ref()
+            .unwrap()
+            .xpub
+            .as_ref()
+            .unwrap()
+            .starts_with("zpub"));
+        assert!(generic
+            .bip86
+            .as_ref()
+            .unwrap()
+            .xpub
+            .as_ref()
+            .unwrap()
+            .starts_with("xpub"));
+
+        // verify taproot address format (bc1p prefix)
+        assert!(generic
+            .bip86
+            .as_ref()
+            .unwrap()
+            .first
+            .as_ref()
+            .unwrap()
+            .starts_with("bc1p"));
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -17,6 +17,7 @@ pub struct GenericJson {
     pub bip44: Option<SingleSig>,
     pub bip49: Option<SingleSig>,
     pub bip84: Option<SingleSig>,
+    pub bip86: Option<SingleSig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,11 +77,13 @@ impl Json {
         let bip44 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2pkh)?;
         let bip49 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2shP2wpkh)?;
         let bip84 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2wpkh)?;
+        let bip86 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2tr)?;
 
         Ok(Self {
             bip44: Some(bip44),
             bip49: Some(bip49),
             bip84: Some(bip84),
+            bip86: Some(bip86),
         })
     }
 }
@@ -146,7 +149,11 @@ mod tests {
 }"#;
 
         let generic = serde_json::from_str::<GenericJson>(passport_json);
-        assert!(generic.is_ok(), "Failed to parse Passport JSON: {:?}", generic.err());
+        assert!(
+            generic.is_ok(),
+            "Failed to parse Passport JSON: {:?}",
+            generic.err()
+        );
 
         let generic = generic.unwrap();
 

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -154,4 +154,37 @@ mod tests {
 
         assert_eq!(xpub.xpub.to_string().as_str(), xpub_str);
     }
+
+    #[test]
+    fn test_zpub_to_xpub_direct() {
+        // same test vector as test_zpub_to_xpub above
+        let zpub = "zpub6rNrPrFwgm4wMBSysetK5tpLBS2HYT8TDKQA6amxFHKJUnQq8rNtc4JDfGYPbvF9wJyagPpG1Faqnfe3BB8XzKon8LwW9KkMWyAQ4RQHzB1";
+        let expected = "xpub6CiKnWv7PPyyeb4kCwK4fidKqVjPfD9TP6MiXnzBVGZYNanNdY3mMvywcrdDc6wK82jyBSd95vsk26QujnJWPrSaPfYeyW7NyX37HHGtfQM";
+
+        let result = zpub_to_xpub(zpub).expect("should convert zpub to xpub");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_ypub_to_xpub_direct() {
+        let ypub = "ypub6X2aUb9NXbQM65mQy6oFECSB1CdSanwXHGTUcw7vt2LaAteuYtLoDQ6ao1fXDsenrZjgJKJyHvLypBBeo59cSKUivvwW8S6k7PVvQkVosxZ";
+        let expected = "xpub6CCKAvUTNursEnaJ8k1d27LfqEUzeAx2N9wFqYE3W1xh7nqgJEBEbLSSmohwDxzsSvcsYqiQqFzRvta65Njbe5o84bF5YXHFqfSH2Dkhonm";
+
+        let result = ypub_to_xpub(ypub).expect("should convert ypub to xpub");
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_zpub_to_xpub_invalid() {
+        let invalid = "zpubINVALID";
+        let result = zpub_to_xpub(invalid);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ypub_to_xpub_invalid() {
+        let invalid = "ypubINVALID";
+        let result = ypub_to_xpub(invalid);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BIP-86 (Taproot) support for descriptors and JSON exports.
  * Added automatic normalization of SLIP-132 encoded keys (zpub/ypub) for imports.
  * Added Passport and other wallet export handling for zpub/ypub formats.

* **Breaking**
  * JSON export representation changed; consumers may need to adapt to the updated structure.

* **Tests**
  * Added tests for Taproot/Passport parsing, xpub prefix handling, and address format verification.

* **Chores**
  * Package version bumped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->