### PR TITLE
Fix P2shP2wpkh derivation path (missing /0')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.4.1] [2025-11-27]
+
+### Fixed
+
+- P2shP2wpkh (BIP49) derivation path was incorrectly `49'/0'` instead of `49'/0'/0'`
+
 ## [0.4.0] [2025-04-23]
 
 - Add `key_expressions` module that can parse key expressions (BIP380)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "pubport"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bitcoin",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubport"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for parsing hardware wallet export formats"

--- a/src/descriptor/script_type.rs
+++ b/src/descriptor/script_type.rs
@@ -51,7 +51,7 @@ impl ScriptType {
     pub fn descriptor_derivation_path(&self) -> &'static str {
         match self {
             ScriptType::P2pkh => "44'/0'/0'",
-            ScriptType::P2shP2wpkh => "49'/0'",
+            ScriptType::P2shP2wpkh => "49'/0'/0'",
             ScriptType::P2wpkh => "84'/0'/0'",
         }
     }


### PR DESCRIPTION
The BIP49 derivation path was incorrectly set to "49'/0'" instead of "49'/0'/0'". This was introduced in commit 676ddc3 when fixing the trailing /0 issue.

Bump version to 0.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the P2shP2wpkh (BIP49) derivation path to comply with the proper standard, ensuring accurate HD wallet key derivation for wrapped segwit addresses.

* **Chores**
  * Bumped version to 0.4.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->