### PR TITLE
Fix SLIP-132 descriptor metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
 
 - Private extended keys and uppercase multisig SLIP-132 prefixes now return
   typed unsupported-key errors instead of generic xpub parse failures
+- `ScriptType::descriptor_derivation_path` now returns `String` instead of
+  `&'static str`
 - `KeyExpression` now includes the original extended public key format so
   origin-less SLIP-132 key expressions keep their advertised script purpose
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Added
+
+- Support Bitcoin public SLIP-132 extended keys across bare key, JSON,
+  Electrum, Wasabi, and BIP380 key-expression imports
+- Support testnet single-sig SLIP-132 prefixes `upub` and `vpub`
+
+### Changed
+
+- Bare `ypub` and `upub` imports now create only BIP49 descriptors
+- Bare `zpub` and `vpub` imports now create only BIP84 descriptors
+- SLIP-132 keys are normalized to standard `xpub` or `tpub` in descriptor
+  output
+
+### Deprecated
+
+- `xpub::zpub_to_xpub` and `xpub::ypub_to_xpub`; use
+  `xpub::to_standard_extended_public_key` instead
+
+### Breaking
+
+- Private extended keys and uppercase multisig SLIP-132 prefixes now return
+  typed unsupported-key errors instead of generic xpub parse failures
+- `KeyExpression` now includes the original extended public key format so
+  origin-less SLIP-132 key expressions keep their advertised script purpose
+
 ## [0.5.0] [2025-11-27]
 
 ### Added

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -122,14 +122,7 @@ impl Descriptors {
         let script_type = single_sig.name.ok_or(Error::MissingScriptType)?;
         let xpub_str = single_sig.xpub.ok_or(Error::MissingXpub)?;
 
-        // convert SLIP-132 encoded keys (zpub, ypub) to standard xpub format
-        let xpub = if xpub_str.starts_with("zpub") {
-            xpub::zpub_to_xpub(&xpub_str)?
-        } else if xpub_str.starts_with("ypub") {
-            xpub::ypub_to_xpub(&xpub_str)?
-        } else {
-            xpub_str
-        };
+        let xpub = xpub::Xpub::try_from(xpub_str.as_str())?;
 
         let fingerprint = fingerprint
             .ok_or(Error::MissingFingerprint)?
@@ -247,7 +240,7 @@ impl TryFrom<WasabiJson> for Descriptors {
     fn try_from(json: WasabiJson) -> Result<Self, Self::Error> {
         let fingerprint = json.master_fingerprint.to_ascii_lowercase();
         let derivation_path = "84h/0h/0h";
-        let xpub = json.ext_pub_key;
+        let xpub = xpub::Xpub::try_from(json.ext_pub_key.as_str())?;
 
         let script = format!("[{fingerprint}/{derivation_path}]{xpub}/<0;1>/*");
         let desc = ScriptType::P2wpkh.wrap_with(&script);

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -249,8 +249,9 @@ impl TryFrom<WasabiJson> for Descriptors {
 
     fn try_from(json: WasabiJson) -> Result<Self, Self::Error> {
         let fingerprint = json.master_fingerprint.to_ascii_lowercase();
-        let derivation_path = "84h/0h/0h";
         let xpub = xpub::Xpub::try_from(json.ext_pub_key.as_str())?;
+        let derivation_path =
+            ScriptType::P2wpkh.descriptor_derivation_path_for_coin_type(xpub.coin_type());
 
         let script = format!("[{fingerprint}/{derivation_path}]{xpub}/<0;1>/*");
         let desc = ScriptType::P2wpkh.wrap_with(&script);
@@ -482,6 +483,28 @@ mod tests {
 
         assert_eq!(desc.external, known_desc().external);
         assert_eq!(desc.internal, known_desc().internal);
+    }
+
+    #[test]
+    fn test_parse_wasabi_with_testnet_slip132_key() {
+        let mut decoded = bitcoin::base58::decode_check(
+            "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+        )
+        .unwrap();
+        decoded[0..4].copy_from_slice(&[0x04, 0x5f, 0x1c, 0xf6]);
+        let vpub = bitcoin::base58::encode_check(&decoded);
+        let json = format!(
+            r#"{{
+            "ColdCardFirmwareVersion": "5.4.0",
+            "MasterFingerprint": "817E7BE0",
+            "ExtPubKey": "{vpub}"
+        }}"#
+        );
+
+        let json = serde_json::from_str::<WasabiJson>(&json).unwrap();
+        let desc = Descriptors::try_from(json).unwrap();
+
+        assert!(desc.external.to_string().contains("/84'/1'/0']tpub"));
     }
 
     #[test]

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -144,11 +144,20 @@ impl Descriptors {
         xpub: bitcoin::bip32::Xpub,
         script_type: ScriptType,
     ) -> Result<Self, Error> {
+        Self::try_from_child_xpub_with_coin_type(xpub, script_type, 0)
+    }
+
+    pub fn try_from_child_xpub_with_coin_type(
+        xpub: bitcoin::bip32::Xpub,
+        script_type: ScriptType,
+        coin_type: u32,
+    ) -> Result<Self, Error> {
         if xpub.depth == 0 {
             return Err(Error::MasterXpub);
         }
 
-        let descriptor_derivation_path = script_type.descriptor_derivation_path();
+        let descriptor_derivation_path =
+            script_type.descriptor_derivation_path_for_coin_type(coin_type);
 
         // with just the child xpub we can't get the master fingerprint
         let fingerprint = "00000000";
@@ -162,6 +171,7 @@ impl Descriptors {
     pub fn try_from_key_expression(key_expression: &KeyExpression) -> Result<Self, Error> {
         if let KeyExpression {
             xpub,
+            xpub_original_format: _,
             master_fingerprint: Some(master_fingerprint),
             origin_derivation_path: Some(path),
             xpub_derivation_path: _,

--- a/src/descriptor.rs
+++ b/src/descriptor.rs
@@ -171,10 +171,9 @@ impl Descriptors {
     pub fn try_from_key_expression(key_expression: &KeyExpression) -> Result<Self, Error> {
         if let KeyExpression {
             xpub,
-            xpub_original_format: _,
             master_fingerprint: Some(master_fingerprint),
             origin_derivation_path: Some(path),
-            xpub_derivation_path: _,
+            ..
         } = key_expression
         {
             let script_type = ScriptType::try_from_derivation_path(path)?;

--- a/src/descriptor/script_type.rs
+++ b/src/descriptor/script_type.rs
@@ -54,12 +54,16 @@ impl ScriptType {
         }
     }
 
-    pub fn descriptor_derivation_path(&self) -> &'static str {
+    pub fn descriptor_derivation_path(&self) -> String {
+        self.descriptor_derivation_path_for_coin_type(0)
+    }
+
+    pub fn descriptor_derivation_path_for_coin_type(&self, coin_type: u32) -> String {
         match self {
-            ScriptType::P2pkh => "44'/0'/0'",
-            ScriptType::P2shP2wpkh => "49'/0'/0'",
-            ScriptType::P2wpkh => "84'/0'/0'",
-            ScriptType::P2tr => "86'/0'/0'",
+            ScriptType::P2pkh => format!("44'/{coin_type}'/0'"),
+            ScriptType::P2shP2wpkh => format!("49'/{coin_type}'/0'"),
+            ScriptType::P2wpkh => format!("84'/{coin_type}'/0'"),
+            ScriptType::P2tr => format!("86'/{coin_type}'/0'"),
         }
     }
 

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -125,6 +125,10 @@ impl Format {
             return Ok(Format::Descriptor(desc));
         }
 
+        if let Ok(json) = Json::try_from_child_xpub_str(string) {
+            return Ok(Format::Json(Box::new(json)));
+        }
+
         if let Ok(key_expression) = KeyExpression::try_from_str(string) {
             if let Ok(desc) = Descriptors::try_from_key_expression(&key_expression) {
                 return Ok(Format::KeyExpression(desc));
@@ -142,6 +146,12 @@ impl Format {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bitcoin::base58;
+
+    const BIP49_YPUB: &str = "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP";
+    const BIP84_ZPUB: &str = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs";
+    const UPUB_VERSION: [u8; 4] = [0x04, 0x4a, 0x52, 0x62];
+    const VPUB_VERSION: [u8; 4] = [0x04, 0x5f, 0x1c, 0xf6];
 
     #[test]
     fn test_parse_all_formats() {
@@ -167,6 +177,117 @@ mod tests {
         let xpub = "xpub6CiKnWv7PPyyeb4kCwK4fidKqVjPfD9TP6MiXnzBVGZYNanNdY3mMvywcrdDc6wK82jyBSd95vsk26QujnJWPrSaPfYeyW7NyX37HHGtfQM";
         let format = Format::try_new_from_str(xpub);
         assert!(format.is_ok());
+    }
+
+    #[test]
+    fn test_parse_bare_ypub_only_returns_bip49() {
+        let format = Format::try_new_from_str(BIP49_YPUB).unwrap();
+        let Format::Json(json) = format else {
+            panic!("Expected Format::Json");
+        };
+
+        assert!(json.bip44.is_none());
+        assert!(json.bip49.is_some());
+        assert!(json.bip84.is_none());
+        assert!(json.bip86.is_none());
+        assert!(json
+            .bip49
+            .unwrap()
+            .external
+            .to_string()
+            .starts_with("sh(wpkh("));
+    }
+
+    #[test]
+    fn test_parse_bare_zpub_only_returns_bip84() {
+        let format = Format::try_new_from_str(BIP84_ZPUB).unwrap();
+        let Format::Json(json) = format else {
+            panic!("Expected Format::Json");
+        };
+
+        assert!(json.bip44.is_none());
+        assert!(json.bip49.is_none());
+        assert!(json.bip84.is_some());
+        assert!(json.bip86.is_none());
+        assert!(json
+            .bip84
+            .unwrap()
+            .external
+            .to_string()
+            .starts_with("wpkh("));
+    }
+
+    #[test]
+    fn test_parse_generic_json_with_testnet_slip132_keys() {
+        let upub = key_with_version(BIP49_YPUB, UPUB_VERSION);
+        let vpub = key_with_version(BIP84_ZPUB, VPUB_VERSION);
+        let json_str = format!(
+            r#"{{
+  "xfp": "73c5da0a",
+  "bip49": {{
+    "deriv": "m/49'/1'/0'",
+    "xpub": "{upub}"
+  }},
+  "bip84": {{
+    "deriv": "m/84'/1'/0'",
+    "xpub": "{vpub}"
+  }}
+}}"#
+        );
+
+        let format = Format::try_new_from_str(&json_str).unwrap();
+        let Format::Json(json) = format else {
+            panic!("Expected Format::Json");
+        };
+
+        let bip49 = json.bip49.expect("bip49 should be present");
+        let bip84 = json.bip84.expect("bip84 should be present");
+
+        assert!(bip49.external.to_string().contains("tpub"));
+        assert!(bip49.external.to_string().starts_with("sh(wpkh("));
+        assert!(bip84.external.to_string().contains("tpub"));
+        assert!(bip84.external.to_string().starts_with("wpkh("));
+        assert!(json.bip44.is_none());
+        assert!(json.bip86.is_none());
+    }
+
+    #[test]
+    fn test_parse_electrum_with_testnet_slip132_keys() {
+        for (derivation, key, expected_start) in [
+            (
+                "m/49h/1h/0h",
+                key_with_version(BIP49_YPUB, UPUB_VERSION),
+                "sh(wpkh(",
+            ),
+            (
+                "m/84h/1h/0h",
+                key_with_version(BIP84_ZPUB, VPUB_VERSION),
+                "wpkh(",
+            ),
+        ] {
+            let json_str = format!(
+                r#"{{
+  "seed_version": 17,
+  "use_encryption": false,
+  "wallet_type": "standard",
+  "keystore": {{
+    "type": "hardware",
+    "hw_type": "coldcard",
+    "label": "Testnet Import",
+    "derivation": "{derivation}",
+    "xpub": "{key}"
+  }}
+}}"#
+            );
+
+            let format = Format::try_new_from_str(&json_str).unwrap();
+            let Format::Electrum(desc) = format else {
+                panic!("Expected Format::Electrum");
+            };
+
+            assert!(desc.external.to_string().starts_with(expected_start));
+            assert!(desc.external.to_string().contains("tpub"));
+        }
     }
 
     #[test]
@@ -230,5 +351,11 @@ mod tests {
             }
             _ => panic!("Expected Format::Json"),
         }
+    }
+
+    fn key_with_version(key: &str, version: [u8; 4]) -> String {
+        let mut decoded = base58::decode_check(key).expect("valid test vector");
+        decoded[0..4].copy_from_slice(&version);
+        base58::encode_check(&decoded)
     }
 }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -134,7 +134,14 @@ impl Format {
                 return Ok(Format::KeyExpression(desc));
             }
 
-            let json = Json::try_from_child_xpub(key_expression.xpub)?;
+            let json = if let Some(original_format) = key_expression.xpub_original_format {
+                Json::try_from_child_xpub_with_original_format(
+                    key_expression.xpub,
+                    original_format,
+                )?
+            } else {
+                Json::try_from_child_xpub(key_expression.xpub)?
+            };
             return Ok(Format::Json(Box::new(json)));
         }
 
@@ -150,6 +157,7 @@ mod tests {
 
     const BIP49_YPUB: &str = "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP";
     const BIP84_ZPUB: &str = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs";
+    const TPUB_VERSION: [u8; 4] = [0x04, 0x35, 0x87, 0xcf];
     const UPUB_VERSION: [u8; 4] = [0x04, 0x4a, 0x52, 0x62];
     const VPUB_VERSION: [u8; 4] = [0x04, 0x5f, 0x1c, 0xf6];
 
@@ -218,6 +226,57 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_suffixed_zpub_only_returns_bip84() {
+        let input = format!("{BIP84_ZPUB}/0/*");
+        let format = Format::try_new_from_str(&input).unwrap();
+        let Format::Json(json) = format else {
+            panic!("Expected Format::Json");
+        };
+
+        assert!(json.bip44.is_none());
+        assert!(json.bip49.is_none());
+        assert!(json.bip84.is_some());
+        assert!(json.bip86.is_none());
+    }
+
+    #[test]
+    fn test_parse_bare_testnet_slip132_uses_testnet_coin_type() {
+        let upub = key_with_version(BIP49_YPUB, UPUB_VERSION);
+        let vpub = key_with_version(BIP84_ZPUB, VPUB_VERSION);
+
+        let upub_format = Format::try_new_from_str(&upub).unwrap();
+        let Format::Json(upub_json) = upub_format else {
+            panic!("Expected Format::Json");
+        };
+        let vpub_format = Format::try_new_from_str(&vpub).unwrap();
+        let Format::Json(vpub_json) = vpub_format else {
+            panic!("Expected Format::Json");
+        };
+
+        let upub_desc = upub_json.bip49.unwrap().external.to_string();
+        let vpub_desc = vpub_json.bip84.unwrap().external.to_string();
+
+        assert!(upub_desc.contains("/49'/1'/0']tpub"));
+        assert!(vpub_desc.contains("/84'/1'/0']tpub"));
+    }
+
+    #[test]
+    fn test_parse_bare_tpub_uses_testnet_coin_type() {
+        let tpub = key_with_version(BIP84_ZPUB, TPUB_VERSION);
+        let format = Format::try_new_from_str(&tpub).unwrap();
+        let Format::Json(json) = format else {
+            panic!("Expected Format::Json");
+        };
+
+        assert!(json
+            .bip84
+            .unwrap()
+            .external
+            .to_string()
+            .contains("/84'/1'/0']tpub"));
+    }
+
+    #[test]
     fn test_parse_generic_json_with_testnet_slip132_keys() {
         let upub = key_with_version(BIP49_YPUB, UPUB_VERSION);
         let vpub = key_with_version(BIP84_ZPUB, VPUB_VERSION);
@@ -245,8 +304,10 @@ mod tests {
 
         assert!(bip49.external.to_string().contains("tpub"));
         assert!(bip49.external.to_string().starts_with("sh(wpkh("));
+        assert!(bip49.external.to_string().contains("/49'/1'/0']tpub"));
         assert!(bip84.external.to_string().contains("tpub"));
         assert!(bip84.external.to_string().starts_with("wpkh("));
+        assert!(bip84.external.to_string().contains("/84'/1'/0']tpub"));
         assert!(json.bip44.is_none());
         assert!(json.bip86.is_none());
     }

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -125,9 +125,10 @@ impl Format {
             return Ok(Format::Descriptor(desc));
         }
 
-        if let Ok(json) = Json::try_from_child_xpub_str(string) {
-            return Ok(Format::Json(Box::new(json)));
-        }
+        let child_xpub_error = match Json::try_from_child_xpub_str(string) {
+            Ok(json) => return Ok(Format::Json(Box::new(json))),
+            Err(error) => error,
+        };
 
         if let Ok(key_expression) = KeyExpression::try_from_str(string) {
             if let Ok(desc) = Descriptors::try_from_key_expression(&key_expression) {
@@ -145,8 +146,7 @@ impl Format {
             return Ok(Format::Json(Box::new(json)));
         }
 
-        let json = Json::try_from_child_xpub_str(string)?;
-        Ok(Format::Json(Box::new(json)))
+        Err(child_xpub_error)
     }
 }
 

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -130,23 +130,25 @@ impl Format {
             Err(error) => error,
         };
 
-        if let Ok(key_expression) = KeyExpression::try_from_str(string) {
-            if let Ok(desc) = Descriptors::try_from_key_expression(&key_expression) {
-                return Ok(Format::KeyExpression(desc));
-            }
+        let Ok(key_expression) = KeyExpression::try_from_str(string) else {
+            return Err(child_xpub_error);
+        };
 
-            let json = if let Some(original_format) = key_expression.xpub_original_format {
-                Json::try_from_child_xpub_with_original_format(
-                    key_expression.xpub,
-                    original_format,
-                )?
-            } else {
-                Json::try_from_child_xpub(key_expression.xpub)?
-            };
-            return Ok(Format::Json(Box::new(json)));
+        if key_expression.has_descriptor_fields() {
+            let desc = Descriptors::try_from_key_expression(&key_expression)?;
+            return Ok(Format::KeyExpression(desc));
         }
 
-        Err(child_xpub_error)
+        let json = match key_expression.xpub_original_format {
+            Some(original_format) => Json::try_from_child_xpub_with_original_format(
+                key_expression.xpub,
+                original_format,
+            )?,
+
+            None => Json::try_from_child_xpub(key_expression.xpub)?,
+        };
+
+        Ok(Format::Json(Box::new(json)))
     }
 }
 
@@ -237,6 +239,33 @@ mod tests {
         assert!(json.bip49.is_none());
         assert!(json.bip84.is_some());
         assert!(json.bip86.is_none());
+    }
+
+    #[test]
+    fn test_parse_key_expression_only_falls_back_when_incomplete() {
+        let input = format!("{BIP84_ZPUB}/0/*");
+        let format = Format::try_new_from_str(&input).unwrap();
+        let Format::Json(json) = format else {
+            panic!("Expected Format::Json");
+        };
+
+        assert!(json.bip44.is_none());
+        assert!(json.bip49.is_none());
+        assert!(json.bip84.is_some());
+        assert!(json.bip86.is_none());
+    }
+
+    #[test]
+    fn test_parse_key_expression_returns_non_incomplete_descriptor_errors() {
+        let input = format!("[deadbeef/84/0h/0h]{BIP84_ZPUB}/0/*");
+        let result = Format::try_new_from_str(&input);
+
+        assert!(matches!(
+            result,
+            Err(Error::InvalidDescriptor(
+                descriptor::Error::ScriptTypeParseError(_)
+            ))
+        ));
     }
 
     #[test]

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,8 +1,7 @@
-use std::str::FromStr as _;
-
 use crate::{
     descriptor::{Descriptors, ScriptType},
     formats::Json,
+    xpub::{self, SingleSigPurpose},
 };
 use serde::{Deserialize, Serialize};
 
@@ -67,10 +66,9 @@ pub struct SingleSig {
 
 impl Json {
     pub fn try_from_child_xpub_str(string: &str) -> Result<Self, crate::Error> {
-        let xpub =
-            bitcoin::bip32::Xpub::from_str(string).map_err(crate::xpub::Error::InvalidXpub)?;
+        let xpub = xpub::Xpub::try_from(string)?;
 
-        Self::try_from_child_xpub(xpub)
+        Self::try_from_parsed_child_xpub(xpub)
     }
 
     pub fn try_from_child_xpub(xpub: bitcoin::bip32::Xpub) -> Result<Self, crate::Error> {
@@ -85,6 +83,30 @@ impl Json {
             bip84: Some(bip84),
             bip86: Some(bip86),
         })
+    }
+
+    fn try_from_parsed_child_xpub(xpub: xpub::Xpub) -> Result<Self, crate::Error> {
+        let single_sig_purpose = xpub.single_sig_purpose();
+        let xpub = xpub.into_bip32();
+
+        match single_sig_purpose {
+            Some(SingleSigPurpose::Bip49) => Ok(Self {
+                bip44: None,
+                bip49: Some(Descriptors::try_from_child_xpub(
+                    xpub,
+                    ScriptType::P2shP2wpkh,
+                )?),
+                bip84: None,
+                bip86: None,
+            }),
+            Some(SingleSigPurpose::Bip84) => Ok(Self {
+                bip44: None,
+                bip49: None,
+                bip84: Some(Descriptors::try_from_child_xpub(xpub, ScriptType::P2wpkh)?),
+                bip86: None,
+            }),
+            None => Self::try_from_child_xpub(xpub),
+        }
     }
 }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,7 +1,7 @@
 use crate::{
     descriptor::{Descriptors, ScriptType},
     formats::Json,
-    xpub::{self, SingleSigPurpose},
+    xpub::{self, OriginalFormat, SingleSigPurpose},
 };
 use serde::{Deserialize, Serialize};
 
@@ -72,10 +72,24 @@ impl Json {
     }
 
     pub fn try_from_child_xpub(xpub: bitcoin::bip32::Xpub) -> Result<Self, crate::Error> {
-        let bip44 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2pkh)?;
-        let bip49 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2shP2wpkh)?;
-        let bip84 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2wpkh)?;
-        let bip86 = Descriptors::try_from_child_xpub(xpub, ScriptType::P2tr)?;
+        Self::try_from_child_xpub_with_coin_type(xpub, 0)
+    }
+
+    fn try_from_child_xpub_with_coin_type(
+        xpub: bitcoin::bip32::Xpub,
+        coin_type: u32,
+    ) -> Result<Self, crate::Error> {
+        let bip44 =
+            Descriptors::try_from_child_xpub_with_coin_type(xpub, ScriptType::P2pkh, coin_type)?;
+        let bip49 = Descriptors::try_from_child_xpub_with_coin_type(
+            xpub,
+            ScriptType::P2shP2wpkh,
+            coin_type,
+        )?;
+        let bip84 =
+            Descriptors::try_from_child_xpub_with_coin_type(xpub, ScriptType::P2wpkh, coin_type)?;
+        let bip86 =
+            Descriptors::try_from_child_xpub_with_coin_type(xpub, ScriptType::P2tr, coin_type)?;
 
         Ok(Self {
             bip44: Some(bip44),
@@ -87,14 +101,41 @@ impl Json {
 
     fn try_from_parsed_child_xpub(xpub: xpub::Xpub) -> Result<Self, crate::Error> {
         let single_sig_purpose = xpub.single_sig_purpose();
+        let coin_type = xpub.coin_type();
         let xpub = xpub.into_bip32();
 
+        Self::try_from_child_xpub_with_purpose(xpub, single_sig_purpose, coin_type)
+    }
+
+    pub fn try_from_child_xpub_with_original_format(
+        xpub: bitcoin::bip32::Xpub,
+        original_format: OriginalFormat,
+    ) -> Result<Self, crate::Error> {
+        let single_sig_purpose = match original_format {
+            OriginalFormat::Ypub | OriginalFormat::Upub => Some(SingleSigPurpose::Bip49),
+            OriginalFormat::Zpub | OriginalFormat::Vpub => Some(SingleSigPurpose::Bip84),
+            OriginalFormat::Xpub | OriginalFormat::Tpub => None,
+        };
+        let coin_type = match original_format {
+            OriginalFormat::Xpub | OriginalFormat::Ypub | OriginalFormat::Zpub => 0,
+            OriginalFormat::Tpub | OriginalFormat::Upub | OriginalFormat::Vpub => 1,
+        };
+
+        Self::try_from_child_xpub_with_purpose(xpub, single_sig_purpose, coin_type)
+    }
+
+    fn try_from_child_xpub_with_purpose(
+        xpub: bitcoin::bip32::Xpub,
+        single_sig_purpose: Option<SingleSigPurpose>,
+        coin_type: u32,
+    ) -> Result<Self, crate::Error> {
         match single_sig_purpose {
             Some(SingleSigPurpose::Bip49) => Ok(Self {
                 bip44: None,
-                bip49: Some(Descriptors::try_from_child_xpub(
+                bip49: Some(Descriptors::try_from_child_xpub_with_coin_type(
                     xpub,
                     ScriptType::P2shP2wpkh,
+                    coin_type,
                 )?),
                 bip84: None,
                 bip86: None,
@@ -102,10 +143,14 @@ impl Json {
             Some(SingleSigPurpose::Bip84) => Ok(Self {
                 bip44: None,
                 bip49: None,
-                bip84: Some(Descriptors::try_from_child_xpub(xpub, ScriptType::P2wpkh)?),
+                bip84: Some(Descriptors::try_from_child_xpub_with_coin_type(
+                    xpub,
+                    ScriptType::P2wpkh,
+                    coin_type,
+                )?),
                 bip86: None,
             }),
-            None => Self::try_from_child_xpub(xpub),
+            None => Self::try_from_child_xpub_with_coin_type(xpub, coin_type),
         }
     }
 }

--- a/src/key_expression.rs
+++ b/src/key_expression.rs
@@ -107,6 +107,11 @@ impl KeyExpression {
             xpub_derivation_path: derivation_path,
         })
     }
+
+    /// Return whether the key expression includes the fields needed for a descriptor
+    pub fn has_descriptor_fields(&self) -> bool {
+        self.master_fingerprint.is_some() && self.origin_derivation_path.is_some()
+    }
 }
 
 struct Parser<'a> {

--- a/src/key_expression.rs
+++ b/src/key_expression.rs
@@ -59,7 +59,7 @@ pub enum Error {
     KeyOriginWithNoPublicKey(String),
 
     #[error("Failed to parse Xpub: {0}")]
-    XpubParseError(#[from] bitcoin::bip32::Error),
+    XpubParseError(#[from] crate::xpub::Error),
 
     #[error("Failed to parse derivation path: {0}")]
     DerivationPathParseError(bitcoin::bip32::Error),
@@ -89,7 +89,9 @@ impl KeyExpression {
         // check if there's a derivation path after the xpub
         let (xpub_str, derivation_path) = parser.parse_xpub_and_derivation()?;
 
-        let xpub = Xpub::from_str(xpub_str).map_err(Error::XpubParseError)?;
+        let xpub = crate::xpub::Xpub::try_from(xpub_str)
+            .map_err(Error::XpubParseError)?
+            .into_bip32();
 
         Ok(KeyExpression {
             xpub,
@@ -280,6 +282,28 @@ mod tests {
         let input = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL";
         let result = KeyExpression::try_from_str(input).unwrap();
         assert!(matches!(result, KeyExpression { xpub: _, .. }));
+    }
+
+    #[test]
+    fn test_key_expression_with_ypub() {
+        let input = "[73c5da0a/49h/0h/0h]ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP";
+        let result = KeyExpression::try_from_str(input).unwrap();
+
+        assert_eq!(
+            result.xpub.to_string(),
+            "xpub6C6nQwHaWbSrzs5tZ1q7m5R9cPK9eYpNMFesiXsYrgc1P8bvLLAet9JfHjYXKjToD8cBRswJXXbbFpXgwsswVPAZzKMa1jUp2kVkGVUaJa7"
+        );
+    }
+
+    #[test]
+    fn test_key_expression_with_zpub() {
+        let input = "[73c5da0a/84h/0h/0h]zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs";
+        let result = KeyExpression::try_from_str(input).unwrap();
+
+        assert_eq!(
+            result.xpub.to_string(),
+            "xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V"
+        );
     }
 
     #[test]

--- a/src/key_expression.rs
+++ b/src/key_expression.rs
@@ -5,11 +5,17 @@ use bitcoin::bip32::{DerivationPath, Fingerprint, Xpub};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
+use crate::xpub::OriginalFormat;
+
 #[derive(Debug, Clone, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
 /// A parsed key expression
 pub struct KeyExpression {
     /// the public key in xpub format
     pub xpub: Xpub,
+
+    /// the extended public key format before descriptor normalization
+    #[serde(default)]
+    pub xpub_original_format: Option<OriginalFormat>,
 
     /// the master fingerprint if present in the origin
     pub master_fingerprint: Option<Fingerprint>,
@@ -89,12 +95,13 @@ impl KeyExpression {
         // check if there's a derivation path after the xpub
         let (xpub_str, derivation_path) = parser.parse_xpub_and_derivation()?;
 
-        let xpub = crate::xpub::Xpub::try_from(xpub_str)
-            .map_err(Error::XpubParseError)?
-            .into_bip32();
+        let parsed_xpub = crate::xpub::Xpub::try_from(xpub_str).map_err(Error::XpubParseError)?;
+        let xpub_original_format = Some(parsed_xpub.original_format());
+        let xpub = parsed_xpub.into_bip32();
 
         Ok(KeyExpression {
             xpub,
+            xpub_original_format,
             master_fingerprint,
             origin_derivation_path: origin_path,
             xpub_derivation_path: derivation_path,
@@ -317,6 +324,7 @@ mod tests {
                 master_fingerprint: Some(_),
                 origin_derivation_path: Some(_),
                 xpub_derivation_path: None,
+                ..
             }
         ));
     }
@@ -332,6 +340,7 @@ mod tests {
                 master_fingerprint: Some(_),
                 origin_derivation_path: Some(_),
                 xpub_derivation_path: Some(_),
+                ..
             }
         ));
     }
@@ -352,6 +361,7 @@ mod tests {
                 master_fingerprint: Some(_),
                 origin_derivation_path: Some(_),
                 xpub_derivation_path: Some(_),
+                ..
             }
         ));
 
@@ -400,6 +410,7 @@ mod tests {
                 master_fingerprint: Some(_),
                 origin_derivation_path: Some(_),
                 xpub_derivation_path: Some(_),
+                ..
             }
         ));
     }

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -5,22 +5,38 @@ use bitcoin::{
     bip32::{Fingerprint, Xpub as Bip32Xpub},
 };
 
+const EXTENDED_KEY_LENGTH: usize = 78;
+
+const XPUB_VERSION: [u8; 4] = [0x04, 0x88, 0xb2, 0x1e];
+const YPUB_VERSION: [u8; 4] = [0x04, 0x9d, 0x7c, 0xb2];
+const ZPUB_VERSION: [u8; 4] = [0x04, 0xb2, 0x47, 0x46];
+const TPUB_VERSION: [u8; 4] = [0x04, 0x35, 0x87, 0xcf];
+const UPUB_VERSION: [u8; 4] = [0x04, 0x4a, 0x52, 0x62];
+const VPUB_VERSION: [u8; 4] = [0x04, 0x5f, 0x1c, 0xf6];
+
+const XPRV_VERSION: [u8; 4] = [0x04, 0x88, 0xad, 0xe4];
+const YPRV_VERSION: [u8; 4] = [0x04, 0x9d, 0x78, 0x78];
+const ZPRV_VERSION: [u8; 4] = [0x04, 0xb2, 0x43, 0x0c];
+const TPRV_VERSION: [u8; 4] = [0x04, 0x35, 0x83, 0x94];
+const UPRV_VERSION: [u8; 4] = [0x04, 0x4a, 0x4e, 0x28];
+const VPRV_VERSION: [u8; 4] = [0x04, 0x5f, 0x18, 0xbc];
+
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("Invalid xpub: {0}")]
     InvalidXpub(#[from] bitcoin::bip32::Error),
 
-    #[error("Invalid zpub: {0}")]
-    InvalidZpub(#[from] base58::Error),
+    #[error("Invalid extended public key: {0}")]
+    InvalidBase58(#[from] base58::Error),
 
-    #[error("Invalid ypub: {0}")]
-    InvalidYpubDecode(base58::Error),
+    #[error("Invalid extended public key length: {0}")]
+    InvalidExtendedKeyLength(usize),
 
-    #[error("Invalid ypub: {0}")]
-    InvalidYpubLength(usize),
+    #[error("Private extended keys are not supported: {0}")]
+    UnsupportedPrivateKey(&'static str),
 
-    #[error("Not an xpub, zpub or ypub, starts with: {0}")]
-    NotXpub(String),
+    #[error("Unsupported extended public key version: {0:02x?}")]
+    UnsupportedVersion([u8; 4]),
 
     #[error("Too short, only {0} chars long")]
     TooShort(usize),
@@ -41,14 +57,39 @@ impl std::fmt::Display for Xpub {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, derive_more::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
 pub enum OriginalFormat {
-    Zpub,
-    Ypub,
     Xpub,
+    Ypub,
+    Zpub,
+    Tpub,
+    Upub,
+    Vpub,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SingleSigPurpose {
+    Bip49,
+    Bip84,
 }
 
 impl Xpub {
+    pub fn into_bip32(self) -> Bip32Xpub {
+        self.xpub
+    }
+
+    pub fn original_format(&self) -> OriginalFormat {
+        self.original_format
+    }
+
+    pub fn single_sig_purpose(&self) -> Option<SingleSigPurpose> {
+        match self.original_format {
+            OriginalFormat::Ypub | OriginalFormat::Upub => Some(SingleSigPurpose::Bip49),
+            OriginalFormat::Zpub | OriginalFormat::Vpub => Some(SingleSigPurpose::Bip84),
+            OriginalFormat::Xpub | OriginalFormat::Tpub => None,
+        }
+    }
+
     pub fn master_fingerprint(&self) -> Option<Fingerprint> {
         let fingerprint = xpub_to_fingerprint(&self.xpub).ok()?;
         if fingerprint == Fingerprint::default() {
@@ -67,49 +108,24 @@ impl TryFrom<&str> for Xpub {
     type Error = Error;
 
     fn try_from(xpub: &str) -> Result<Self, Self::Error> {
-        let (xpub, original_format) = match &xpub[..4] {
-            "zpub" => (zpub_to_xpub(xpub)?, OriginalFormat::Zpub),
-            "ypub" => (ypub_to_xpub(xpub)?, OriginalFormat::Ypub),
-            "xpub" => (xpub.to_string(), OriginalFormat::Xpub),
-            starting => return Err(Error::NotXpub(starting.to_string())),
-        };
+        if xpub.len() < 4 {
+            return Err(Error::TooShort(xpub.len()));
+        }
+
+        let decoded = base58::decode_check(xpub)?;
+        let (standard_xpub, original_format) = standardize_extended_public_key(decoded)?;
 
         Ok(Self {
-            xpub: Bip32Xpub::from_str(&xpub)?,
+            xpub: Bip32Xpub::from_str(&standard_xpub)?,
             original_format,
         })
     }
 }
 
-pub fn zpub_to_xpub(zpub: &str) -> Result<String, Error> {
-    let decoded = base58::decode_check(zpub)?;
-
-    // Replace version bytes (first 4 bytes) with xpub version
-    let mut xpub_bytes = [0u8; 78];
-    xpub_bytes[0..4].copy_from_slice(&[0x04, 0x88, 0xB2, 0x1E]); // xpub version bytes
-    xpub_bytes[4..].copy_from_slice(&decoded[4..]);
-
-    // Re-encode as xpub
-    let xpub = base58::encode_check(&xpub_bytes);
-
-    Ok(xpub)
-}
-
-pub fn ypub_to_xpub(ypub: &str) -> Result<String, Error> {
-    let decoded = base58::decode_check(ypub).map_err(Error::InvalidYpubDecode)?;
-
-    if decoded.len() != 78 {
-        return Err(Error::InvalidYpubLength(decoded.len()));
-    }
-
-    let mut xpub_bytes = [0u8; 78];
-    xpub_bytes.copy_from_slice(&decoded);
-    xpub_bytes[0..4].copy_from_slice(&[0x04, 0x88, 0xB2, 0x1E]); // xpub version bytes
-
-    // Re-encode as xpub
-    let xpub = base58::encode_check(&xpub_bytes);
-
-    Ok(xpub)
+pub fn to_standard_extended_public_key(xpub: &str) -> Result<String, Error> {
+    let decoded = base58::decode_check(xpub)?;
+    let (standard_xpub, _) = standardize_extended_public_key(decoded)?;
+    Ok(standard_xpub)
 }
 
 pub fn xpub_to_fingerprint(xpub: &Bip32Xpub) -> Result<Fingerprint, Error> {
@@ -121,9 +137,64 @@ pub fn xpub_to_fingerprint(xpub: &Bip32Xpub) -> Result<Fingerprint, Error> {
 }
 
 pub fn xpub_str_to_fingerprint(xpub: &str) -> Result<Fingerprint, Error> {
-    let xpub = Bip32Xpub::from_str(xpub)?;
-    let fingerprint = xpub_to_fingerprint(&xpub)?;
+    let xpub = Xpub::try_from(xpub)?;
+    let fingerprint = xpub_to_fingerprint(&xpub.xpub)?;
     Ok(fingerprint)
+}
+
+fn standardize_extended_public_key(
+    mut decoded: Vec<u8>,
+) -> Result<(String, OriginalFormat), Error> {
+    if decoded.len() != EXTENDED_KEY_LENGTH {
+        return Err(Error::InvalidExtendedKeyLength(decoded.len()));
+    }
+
+    let version = version_bytes(&decoded);
+    let info = version_info(version)?;
+
+    decoded[0..4].copy_from_slice(&info.standard_version);
+    let standard_xpub = base58::encode_check(&decoded);
+    Ok((standard_xpub, info.original_format))
+}
+
+fn version_bytes(decoded: &[u8]) -> [u8; 4] {
+    decoded[0..4]
+        .try_into()
+        .expect("checked extended key length")
+}
+
+fn version_info(version: [u8; 4]) -> Result<VersionInfo, Error> {
+    let info = match version {
+        XPUB_VERSION => VersionInfo::new(OriginalFormat::Xpub, XPUB_VERSION),
+        YPUB_VERSION => VersionInfo::new(OriginalFormat::Ypub, XPUB_VERSION),
+        ZPUB_VERSION => VersionInfo::new(OriginalFormat::Zpub, XPUB_VERSION),
+        TPUB_VERSION => VersionInfo::new(OriginalFormat::Tpub, TPUB_VERSION),
+        UPUB_VERSION => VersionInfo::new(OriginalFormat::Upub, TPUB_VERSION),
+        VPUB_VERSION => VersionInfo::new(OriginalFormat::Vpub, TPUB_VERSION),
+        XPRV_VERSION => return Err(Error::UnsupportedPrivateKey("xprv")),
+        YPRV_VERSION => return Err(Error::UnsupportedPrivateKey("yprv")),
+        ZPRV_VERSION => return Err(Error::UnsupportedPrivateKey("zprv")),
+        TPRV_VERSION => return Err(Error::UnsupportedPrivateKey("tprv")),
+        UPRV_VERSION => return Err(Error::UnsupportedPrivateKey("uprv")),
+        VPRV_VERSION => return Err(Error::UnsupportedPrivateKey("vprv")),
+        version => return Err(Error::UnsupportedVersion(version)),
+    };
+
+    Ok(info)
+}
+
+struct VersionInfo {
+    original_format: OriginalFormat,
+    standard_version: [u8; 4],
+}
+
+impl VersionInfo {
+    fn new(original_format: OriginalFormat, standard_version: [u8; 4]) -> Self {
+        Self {
+            original_format,
+            standard_version,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -131,60 +202,111 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
+    const BIP49_XPUB: &str = "xpub6C6nQwHaWbSrzs5tZ1q7m5R9cPK9eYpNMFesiXsYrgc1P8bvLLAet9JfHjYXKjToD8cBRswJXXbbFpXgwsswVPAZzKMa1jUp2kVkGVUaJa7";
+    const BIP49_YPUB: &str = "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP";
+    const BIP84_XPUB: &str = "xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V";
+    const BIP84_ZPUB: &str = "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs";
+
     #[test]
     fn test_zpub_to_xpub() {
-        let zpub = "zpub6rNrPrFwgm4wMBSysetK5tpLBS2HYT8TDKQA6amxFHKJUnQq8rNtc4JDfGYPbvF9wJyagPpG1Faqnfe3BB8XzKon8LwW9KkMWyAQ4RQHzB1";
-        let xpub_str = "xpub6CiKnWv7PPyyeb4kCwK4fidKqVjPfD9TP6MiXnzBVGZYNanNdY3mMvywcrdDc6wK82jyBSd95vsk26QujnJWPrSaPfYeyW7NyX37HHGtfQM";
-        let xpub = Xpub::try_from(zpub);
+        let xpub = Xpub::try_from(BIP84_ZPUB);
 
         assert!(xpub.is_ok());
         let xpub = xpub.unwrap();
 
-        assert_eq!(xpub.xpub.to_string(), xpub_str);
+        assert_eq!(xpub.xpub.to_string(), BIP84_XPUB);
+        assert_eq!(xpub.original_format(), OriginalFormat::Zpub);
+        assert_eq!(xpub.single_sig_purpose(), Some(SingleSigPurpose::Bip84));
     }
 
     #[test]
     fn test_ypub_to_xpub() {
-        let ypub = "ypub6X2aUb9NXbQM65mQy6oFECSB1CdSanwXHGTUcw7vt2LaAteuYtLoDQ6ao1fXDsenrZjgJKJyHvLypBBeo59cSKUivvwW8S6k7PVvQkVosxZ";
-        let xpub_str = "xpub6CCKAvUTNursEnaJ8k1d27LfqEUzeAx2N9wFqYE3W1xh7nqgJEBEbLSSmohwDxzsSvcsYqiQqFzRvta65Njbe5o84bF5YXHFqfSH2Dkhonm";
-        let xpub = Xpub::try_from(ypub);
+        let xpub = Xpub::try_from(BIP49_YPUB);
 
         assert!(xpub.is_ok());
         let xpub = xpub.unwrap();
 
-        assert_eq!(xpub.xpub.to_string().as_str(), xpub_str);
+        assert_eq!(xpub.xpub.to_string().as_str(), BIP49_XPUB);
+        assert_eq!(xpub.original_format(), OriginalFormat::Ypub);
+        assert_eq!(xpub.single_sig_purpose(), Some(SingleSigPurpose::Bip49));
     }
 
     #[test]
-    fn test_zpub_to_xpub_direct() {
-        // same test vector as test_zpub_to_xpub above
-        let zpub = "zpub6rNrPrFwgm4wMBSysetK5tpLBS2HYT8TDKQA6amxFHKJUnQq8rNtc4JDfGYPbvF9wJyagPpG1Faqnfe3BB8XzKon8LwW9KkMWyAQ4RQHzB1";
-        let expected = "xpub6CiKnWv7PPyyeb4kCwK4fidKqVjPfD9TP6MiXnzBVGZYNanNdY3mMvywcrdDc6wK82jyBSd95vsk26QujnJWPrSaPfYeyW7NyX37HHGtfQM";
+    fn test_upub_to_tpub() {
+        let upub = key_with_version(BIP49_YPUB, UPUB_VERSION);
+        let tpub = key_with_version(BIP49_XPUB, TPUB_VERSION);
 
-        let result = zpub_to_xpub(zpub).expect("should convert zpub to xpub");
-        assert_eq!(result, expected);
+        let xpub = Xpub::try_from(upub.as_str()).expect("should convert upub to tpub");
+
+        assert_eq!(xpub.xpub.to_string(), tpub);
+        assert_eq!(xpub.original_format(), OriginalFormat::Upub);
+        assert_eq!(xpub.single_sig_purpose(), Some(SingleSigPurpose::Bip49));
     }
 
     #[test]
-    fn test_ypub_to_xpub_direct() {
-        let ypub = "ypub6X2aUb9NXbQM65mQy6oFECSB1CdSanwXHGTUcw7vt2LaAteuYtLoDQ6ao1fXDsenrZjgJKJyHvLypBBeo59cSKUivvwW8S6k7PVvQkVosxZ";
-        let expected = "xpub6CCKAvUTNursEnaJ8k1d27LfqEUzeAx2N9wFqYE3W1xh7nqgJEBEbLSSmohwDxzsSvcsYqiQqFzRvta65Njbe5o84bF5YXHFqfSH2Dkhonm";
+    fn test_vpub_to_tpub() {
+        let vpub = key_with_version(BIP84_ZPUB, VPUB_VERSION);
+        let tpub = key_with_version(BIP84_XPUB, TPUB_VERSION);
 
-        let result = ypub_to_xpub(ypub).expect("should convert ypub to xpub");
-        assert_eq!(result, expected);
+        let xpub = Xpub::try_from(vpub.as_str()).expect("should convert vpub to tpub");
+
+        assert_eq!(xpub.xpub.to_string(), tpub);
+        assert_eq!(xpub.original_format(), OriginalFormat::Vpub);
+        assert_eq!(xpub.single_sig_purpose(), Some(SingleSigPurpose::Bip84));
     }
 
     #[test]
-    fn test_zpub_to_xpub_invalid() {
+    fn test_to_standard_extended_public_key() {
+        let result =
+            to_standard_extended_public_key(BIP84_ZPUB).expect("should convert zpub to xpub");
+        assert_eq!(result, BIP84_XPUB);
+    }
+
+    #[test]
+    fn test_invalid_slip132_key() {
         let invalid = "zpubINVALID";
-        let result = zpub_to_xpub(invalid);
+        let result = to_standard_extended_public_key(invalid);
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_ypub_to_xpub_invalid() {
-        let invalid = "ypubINVALID";
-        let result = ypub_to_xpub(invalid);
-        assert!(result.is_err());
+    fn test_private_prefixes_are_not_supported() {
+        for (version, prefix) in [
+            (XPRV_VERSION, "xprv"),
+            (YPRV_VERSION, "yprv"),
+            (ZPRV_VERSION, "zprv"),
+            (TPRV_VERSION, "tprv"),
+            (UPRV_VERSION, "uprv"),
+            (VPRV_VERSION, "vprv"),
+        ] {
+            let key = key_with_version(BIP49_XPUB, version);
+            let result = Xpub::try_from(key.as_str());
+
+            assert!(matches!(
+                result,
+                Err(Error::UnsupportedPrivateKey(actual)) if actual == prefix
+            ));
+        }
+    }
+
+    #[test]
+    fn test_multisig_prefixes_are_not_supported() {
+        for version in [
+            [0x02, 0x95, 0xb4, 0x3f],
+            [0x02, 0xaa, 0x7e, 0xd3],
+            [0x02, 0x42, 0x89, 0xef],
+            [0x02, 0x57, 0x54, 0x83],
+        ] {
+            let key = key_with_version(BIP49_XPUB, version);
+            let result = Xpub::try_from(key.as_str());
+
+            assert!(matches!(result, Err(Error::UnsupportedVersion(_))));
+        }
+    }
+
+    fn key_with_version(key: &str, version: [u8; 4]) -> String {
+        let mut decoded = base58::decode_check(key).expect("valid test vector");
+        decoded[0..4].copy_from_slice(&version);
+        base58::encode_check(&decoded)
     }
 }

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -57,7 +57,19 @@ impl std::fmt::Display for Xpub {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::Display,
+)]
 pub enum OriginalFormat {
     Xpub,
     Ypub,
@@ -67,7 +79,9 @@ pub enum OriginalFormat {
     Vpub,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub enum SingleSigPurpose {
     Bip49,
     Bip84,
@@ -80,6 +94,13 @@ impl Xpub {
 
     pub fn original_format(&self) -> OriginalFormat {
         self.original_format
+    }
+
+    pub fn coin_type(&self) -> u32 {
+        match self.original_format {
+            OriginalFormat::Xpub | OriginalFormat::Ypub | OriginalFormat::Zpub => 0,
+            OriginalFormat::Tpub | OriginalFormat::Upub | OriginalFormat::Vpub => 1,
+        }
     }
 
     pub fn single_sig_purpose(&self) -> Option<SingleSigPurpose> {
@@ -126,6 +147,16 @@ pub fn to_standard_extended_public_key(xpub: &str) -> Result<String, Error> {
     let decoded = base58::decode_check(xpub)?;
     let (standard_xpub, _) = standardize_extended_public_key(decoded)?;
     Ok(standard_xpub)
+}
+
+#[deprecated(since = "0.6.0", note = "use to_standard_extended_public_key")]
+pub fn zpub_to_xpub(zpub: &str) -> Result<String, Error> {
+    to_standard_extended_public_key(zpub)
+}
+
+#[deprecated(since = "0.6.0", note = "use to_standard_extended_public_key")]
+pub fn ypub_to_xpub(ypub: &str) -> Result<String, Error> {
+    to_standard_extended_public_key(ypub)
 }
 
 pub fn xpub_to_fingerprint(xpub: &Bip32Xpub) -> Result<Fingerprint, Error> {


### PR DESCRIPTION
## Summary
- Add support for Bitcoin public SLIP-132 keys across bare imports, JSON, Electrum, Wasabi, and BIP380 key expressions.
- Preserve the original SLIP-132 format through key-expression fallback so suffixed `ypub`/`zpub` inputs keep their intended script type.
- Derive the correct coin type for testnet `upub`/`vpub` and Wasabi `tpub`/`vpub` imports.
- Keep deprecated `xpub::zpub_to_xpub` and `xpub::ypub_to_xpub` as compatibility shims and document the release impact in the changelog.

## Testing
- Added regression coverage for bare and suffixed SLIP-132 key expressions, testnet JSON/Electrum imports, and Wasabi `vpub` handling.
- Ran formatting, clippy, and the full test suite successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SLIP-132 extended key support across bare key, JSON, Electrum, Wasabi, and BIP380 imports.
  * Added testnet single-sig prefix support (upub, vpub).

* **Breaking Changes**
  * Bare ypub/upub → BIP49 only; bare zpub/vpub → BIP84 only.
  * Descriptor outputs normalize SLIP-132 keys to standard xpub/tpub and include coin-type-aware derivation paths.
  * New typed errors for unsupported private-key and uppercase multisig SLIP-132 prefixes.

* **Deprecations**
  * Old SLIP-132-to-standard conversion helpers deprecated in favor of a unified conversion API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->